### PR TITLE
Feature fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,11 +194,12 @@ cython_debug/
 .abstra/
 
 # Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  and can be added to the global gitignore or merged into this file. However, if you prefer,
 #  you could uncomment the following to ignore the entire vscode folder
 # .vscode/
+settings.json
 
 # Ruff stuff:
 .ruff_cache/

--- a/pyhctsa/calculator.py
+++ b/pyhctsa/calculator.py
@@ -124,7 +124,7 @@ def _format_param_value(val, key=None) -> str:
             diffs = [val[i+1] - val[i] for i in range(len(val)-1)]
             if all(d == 1 for d in diffs):
                 # Pass key down for recursion if needed, though usually lists aren't bools
-                return f"{_format_param_value(val[0])}_{_format_param_value(val[-1])}"
+                return f"{_format_param_value(val[0])}_to_{_format_param_value(val[-1])}"
         return "_".join(_format_param_value(x) for x in val)
 
     if isinstance(val, (float, int)):

--- a/pyhctsa/configurations/hctsa.yaml
+++ b/pyhctsa/configurations/hctsa.yaml
@@ -341,7 +341,7 @@ correlation:
     base_name: autocorr_shape
     configs:
       - {stop_when: 'drown', zscore: True}
-      - {stop_when: 'posDrown', zscore: True}
+      - {stop_when: 'pos_drown', zscore: True}
     legacy_name: CO_AutoCorrShape
     ordered_args: ['stop_when']
   

--- a/pyhctsa/operations/correlation.py
+++ b/pyhctsa/operations/correlation.py
@@ -1742,7 +1742,7 @@ def _stat_av(y: ArrayLike, window_stat: str = 'mean', num_seg: int = 5, inc_move
 
     return np.std(qs, ddof=1)/np.std(y, ddof=1)
 
-def autocorr_shape(y: ArrayLike, stop_when: Union[int, str] = 'pos_drown') -> dict:
+def autocorr_shape(y: ArrayLike, stop_when: Union[int, str] = 'posDrown') -> dict:
     """
     How the autocorrelation function changes with the time lag.
 
@@ -1755,7 +1755,7 @@ def autocorr_shape(y: ArrayLike, stop_when: Union[int, str] = 'pos_drown') -> di
         The input time series.
     stop_when : str or int, optional
         The criterion for the maximum lag to measure the ACF up to.
-        Default is ``'pos_drown'``.
+        Default is ``'posDrown'``.
 
     Returns
     --------
@@ -1777,10 +1777,10 @@ def autocorr_shape(y: ArrayLike, stop_when: Union[int, str] = 'pos_drown') -> di
         acf = autocorr(y, taus, 'Fourier')
         n_drown = stop_when
         
-    elif stop_when in ['pos_drown', 'drown', 'double_drown']:
+    elif stop_when in ['posDrown', 'drown', 'doubleDrown']:
         # Compute ACF up to a given threshold:
         n_drown = 0 # the point at which ACF ~ 0
-        if stop_when == 'pos_drown':
+        if stop_when == 'posDrown':
             # stop when ACF drops below threshold, th
             for i in range(1, N+1):
                 acf_val = autocorr(y, i-1, 'Fourier')[0]
@@ -1811,7 +1811,7 @@ def autocorr_shape(y: ArrayLike, stop_when: Union[int, str] = 'pos_drown') -> di
                     acf.append(acf_val)
                     break
                 acf.append(acf_val)
-        elif stop_when == 'double_drown':
+        elif stop_when == 'doubleDrown':
             # Stop at 2*tau, where tau is the lag where ACF ~ 0 (within 1/sqrt(N) threshold)
             for i in range(1, N+1):
                 acf_val = autocorr(y, i-1, 'Fourier')[0]
@@ -1838,7 +1838,7 @@ def autocorr_shape(y: ArrayLike, stop_when: Union[int, str] = 'pos_drown') -> di
     # Basic stats on the ACF
     out['sumacf'] = np.sum(acf)
     out['meanacf'] = np.mean(acf)
-    if stop_when != 'pos_drown':
+    if stop_when != 'posDrown':
         out['meanabsacf'] = np.mean(np.abs(acf))
         out['sumabsacf'] = np.sum(np.abs(acf))
 
@@ -1879,7 +1879,7 @@ def autocorr_shape(y: ArrayLike, stop_when: Union[int, str] = 'pos_drown') -> di
     fit_success = False
     min_pts_to_fit_exp = 4 # (need at least four points to fit exponential)
 
-    if stop_when == 'pos_drown' and nac >= min_pts_to_fit_exp:
+    if stop_when == 'posDrown' and nac >= min_pts_to_fit_exp:
         # Fit exponential decay to (absolute) ACF:
         # (kind of only makes sense for the first positive period)
         exp_func = lambda x, b : np.exp(-b * x)

--- a/pyhctsa/operations/correlation.py
+++ b/pyhctsa/operations/correlation.py
@@ -1742,7 +1742,7 @@ def _stat_av(y: ArrayLike, window_stat: str = 'mean', num_seg: int = 5, inc_move
 
     return np.std(qs, ddof=1)/np.std(y, ddof=1)
 
-def autocorr_shape(y: ArrayLike, stop_when: Union[int, str] = 'posDrown') -> dict:
+def autocorr_shape(y: ArrayLike, stop_when: Union[int, str] = 'pos_drown') -> dict:
     """
     How the autocorrelation function changes with the time lag.
 
@@ -1755,7 +1755,7 @@ def autocorr_shape(y: ArrayLike, stop_when: Union[int, str] = 'posDrown') -> dic
         The input time series.
     stop_when : str or int, optional
         The criterion for the maximum lag to measure the ACF up to.
-        Default is ``'posDrown'``.
+        Default is ``'pos_drown'``.
 
     Returns
     --------
@@ -1777,10 +1777,10 @@ def autocorr_shape(y: ArrayLike, stop_when: Union[int, str] = 'posDrown') -> dic
         acf = autocorr(y, taus, 'Fourier')
         n_drown = stop_when
         
-    elif stop_when in ['posDrown', 'drown', 'doubleDrown']:
+    elif stop_when in ['pos_drown', 'drown', 'double_drown']:
         # Compute ACF up to a given threshold:
         n_drown = 0 # the point at which ACF ~ 0
-        if stop_when == 'posDrown':
+        if stop_when == 'pos_drown':
             # stop when ACF drops below threshold, th
             for i in range(1, N+1):
                 acf_val = autocorr(y, i-1, 'Fourier')[0]
@@ -1811,7 +1811,7 @@ def autocorr_shape(y: ArrayLike, stop_when: Union[int, str] = 'posDrown') -> dic
                     acf.append(acf_val)
                     break
                 acf.append(acf_val)
-        elif stop_when == 'doubleDrown':
+        elif stop_when == 'double_drown':
             # Stop at 2*tau, where tau is the lag where ACF ~ 0 (within 1/sqrt(N) threshold)
             for i in range(1, N+1):
                 acf_val = autocorr(y, i-1, 'Fourier')[0]
@@ -1838,7 +1838,7 @@ def autocorr_shape(y: ArrayLike, stop_when: Union[int, str] = 'posDrown') -> dic
     # Basic stats on the ACF
     out['sumacf'] = np.sum(acf)
     out['meanacf'] = np.mean(acf)
-    if stop_when != 'posDrown':
+    if stop_when != 'pos_drown':
         out['meanabsacf'] = np.mean(np.abs(acf))
         out['sumabsacf'] = np.sum(np.abs(acf))
 
@@ -1879,7 +1879,7 @@ def autocorr_shape(y: ArrayLike, stop_when: Union[int, str] = 'posDrown') -> dic
     fit_success = False
     min_pts_to_fit_exp = 4 # (need at least four points to fit exponential)
 
-    if stop_when == 'posDrown' and nac >= min_pts_to_fit_exp:
+    if stop_when == 'pos_drown' and nac >= min_pts_to_fit_exp:
         # Fit exponential decay to (absolute) ACF:
         # (kind of only makes sense for the first positive period)
         exp_func = lambda x, b : np.exp(-b * x)

--- a/pyhctsa/operations/information.py
+++ b/pyhctsa/operations/information.py
@@ -14,7 +14,7 @@ def _get_corr_fn(y: np.ndarray, min_what: str, extra_param: Union[int, float, No
     from ..operations.correlation import autocorr, automutual_info
 
     if min_what in ['ac', 'corr']:
-        return lambda x: autocorr(y, tau=x, method='Fourier')
+        return lambda x: autocorr(y, tau=x, method='Fourier').item()
     elif min_what == 'mi-hist':
         num_bins = int(extra_param) if extra_param else 10
         return lambda x: _mi_bin(y[:-x], y[x:], 'range', 'range', num_bins)

--- a/pyhctsa/operations/stationarity.py
+++ b/pyhctsa/operations/stationarity.py
@@ -569,7 +569,7 @@ def range_evolve(y: ArrayLike) -> dict:
         if N >= n_val:
             out[f'nuql{n_val}'] = lunique(cums[:n_val])/out['totnuq']
         else:
-            out[f'nuql{N}'] = np.nan
+            out[f'nuql{n_val}'] = np.nan
     # (**2**) Actual proportion of full range captured at different points
     out['p1'] = cums[int(np.ceil(N * 0.01)) - 1]/fullr
     out['p10'] = cums[int(np.ceil(N * 0.1)) - 1]/fullr

--- a/pyhctsa/operations/stationarity.py
+++ b/pyhctsa/operations/stationarity.py
@@ -1056,7 +1056,7 @@ def sliding_window(y: ArrayLike, window_stat: str = 'mean', across_win_stat: str
             qs[i] = moments(y[_get_window(i, inc, win_length)], 5)
     elif window_stat == 'AC1':
         for i in range(num_steps):
-            qs[i] = autocorr(y[_get_window(i, inc, win_length)], 1, 'Fourier')
+            qs[i] = np.asarray(autocorr(y[_get_window(i, inc, win_length)], 1, 'Fourier')).item()
     else:
         raise ValueError(f"Unknown statistic '{window_stat}'")
     

--- a/pyhctsa/operations/symbolic.py
+++ b/pyhctsa/operations/symbolic.py
@@ -81,8 +81,8 @@ def surprise(y: ArrayLike, what_prior: str = 'dist', memory: float = 0.2, num_gr
         if what_prior == 'dist':
             # uses the distribution up to memory to inform the next point
             # had to be careful with indexing, arange() works like matlab's : operator
-            store[i] = p
             p = np.sum(yth[rs[0, i]-memory:rs[0, i]] == yth[rs[0, i]])/memory
+            store[i] = p
         elif what_prior == 'T1':
             # uses one-point correlations in memory to inform the next point
             # estimate transition probabilites from data in memory


### PR DESCRIPTION
A few fixes:
- `pyhctsa/operations/stationarity.py`: `nuql{N}` → `nuql{n_val}` so missing-length keys (e.g. `nuql1000`) keep a stable name
- `pyhctsa/operations/stationarity.py`: get `autocorr` result with `.item()` for the AC1 window stat so that a scalar is returned
- `pyhctsa/operations/correlation.py`: rename pos_down to posDown for consistency with the config YAML (previously mismatched; could alternatively rename all posDown -> pos_down)
- `pyhctsa/operations/symbolic.py`: fix value being assigned before creation by swapping line order