### PR TITLE
drop calc.summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ res = calc.extract(data)
 Note that each time-series instances does *not* have to be the same length to compute a vector of features. 
 The results of the extraction will be returned in a pandas dataframe of shape $N \times F$, where $N$ is the number of time-series instances and $F$ is the number of time-series features.
 
-You can also inspect the quality of the extracted feature values by calling ```calc.summary()```.  
-
 # 📘 Tutorials
 New to _pyhctsa_? Step-by-step tutorials and example workflows are available in the repository
 👉 [`/tutorials`](./tutorials)

--- a/pyhctsa/calculator.py
+++ b/pyhctsa/calculator.py
@@ -184,7 +184,6 @@ class FeatureCalculator:
     >>> fc = FeatureCalculator()  # Load default configuration
     >>> x = np.random.randn(1000)
     >>> df = fc.extract(x)
-    >>> print(fc.summary())
     """
     def __init__(self, config_path: Union[str, None] = None):
         """
@@ -359,7 +358,7 @@ class FeatureCalculator:
         df = pd.json_normalize(rows)
         # assign row names
         df.index = pd.Index(labels_list, name="instance")
-        # meta data for summary
+        # metadata
         self._last_elapsed = elapsed
         self._errors = df.map(classify_output)
 


### PR DESCRIPTION
Drop references to `calc.summary()` in both the README and docstrings.