### PR TITLE
Vectorize AC features

### DIFF
--- a/pyhctsa/operations/correlation.py
+++ b/pyhctsa/operations/correlation.py
@@ -1271,14 +1271,15 @@ def embed2_shapes(y: ArrayLike, tau: Union[str, int, None] = 'tau',
     N = len(m)
 
     # Start the analysis
-    counts = np.zeros(N)
     if shape == 'circle':
         # Puts a circle around each point in the embedding space in turn
-        # counts how many pts are inside this shape, looks at the time series thus formed
-        for i in range(N): # across all pts in the time series
-            m_c = m - m[i] # pts wrt current pt i
-            m_c_d = np.sum(m_c**2, axis=1) # Euclidean distances from pt i
-            counts[i] = np.sum(m_c_d <= r**2) # number of pts enclosed in a circle of radius r
+        # counts how many pts are inside this shape, looks at the time series thus formed.
+        # Vectorised: one pairwise squared-distance matrix (sqeuclidean == the loop's
+        # sum of squared diffs exactly), then count <= r**2 per row. Diagonal is 0, so
+        # the self-count subtraction below is preserved. O(N^2) memory.
+        from scipy.spatial.distance import cdist
+        m_c_d = cdist(m, m, metric='sqeuclidean')
+        counts = np.sum(m_c_d <= r**2, axis=1).astype(float)
     else:
         raise ValueError(f"Unknown shape '{shape}'")
     counts -= 1 # ignore self counts
@@ -1784,10 +1785,14 @@ def autocorr_shape(y: ArrayLike, stop_when: Union[int, str] = 'pos_drown') -> di
     elif stop_when in ['pos_drown', 'drown', 'double_drown']:
         # Compute ACF up to a given threshold:
         n_drown = 0 # the point at which ACF ~ 0
+        # The Fourier ACF depends only on N, so compute the whole (lag-indexed) curve
+        # once and read acf_full[i-1] instead of recomputing a full FFT every lag.
+        # acf_full[i-1] is bit-identical to autocorr(y, i-1, 'Fourier')[0].
+        acf_full = autocorr(y, [], 'Fourier')
         if stop_when == 'pos_drown':
             # stop when ACF drops below threshold, th
             for i in range(1, N+1):
-                acf_val = autocorr(y, i-1, 'Fourier')[0]
+                acf_val = acf_full[i-1]
                 if np.isnan(acf_val):
                     logger.warning("Weird time series (constant?)")
                     out = np.nan
@@ -1808,7 +1813,7 @@ def autocorr_shape(y: ArrayLike, stop_when: Union[int, str] = 'pos_drown') -> di
         elif stop_when == 'drown':
             # Stop when ACF is very close to 0 (within threshold, th = 2/sqrt(N))
             for i in range(1, N+1):
-                acf_val = autocorr(y, i-1, 'Fourier')[0] # acf vector indicies are not lags
+                acf_val = acf_full[i-1] # acf vector indicies are not lags
                 # if positive and less than thresh
                 if i > 0 and abs(acf_val) < th:
                     n_drown = i
@@ -1818,7 +1823,7 @@ def autocorr_shape(y: ArrayLike, stop_when: Union[int, str] = 'pos_drown') -> di
         elif stop_when == 'double_drown':
             # Stop at 2*tau, where tau is the lag where ACF ~ 0 (within 1/sqrt(N) threshold)
             for i in range(1, N+1):
-                acf_val = autocorr(y, i-1, 'Fourier')[0]
+                acf_val = acf_full[i-1]
                 if n_drown > 0 and i == n_drown * 2:
                     acf.append(acf_val)
                     break

--- a/pyhctsa/operations/entropy.py
+++ b/pyhctsa/operations/entropy.py
@@ -511,7 +511,10 @@ def _embed(x: ArrayLike, order: int, delay: int = 1) -> ArrayLike:
     N = x.shape[0]
     if N - (order - 1) * delay <= 0:
         raise ValueError("Time series is too short for the given order and delay.")
-    return np.array([x[i:i + order * delay:delay] for i in range(N - (order - 1) * delay)])
+    # Build the delay-embedding by one broadcast gather instead of a per-row comprehension
+    nrows = N - (order - 1) * delay
+    idx = np.arange(nrows)[:, None] + delay * np.arange(order)[None, :]
+    return x[idx]
 
 def _app_samp_entropy(
         x: ArrayLike,

--- a/pyhctsa/operations/information.py
+++ b/pyhctsa/operations/information.py
@@ -853,14 +853,11 @@ def _rm_histogram_2(*args):
     xx = xx.astype(int)  # cast all the values in xx and yy to ints for use in indexing, already rounded in previous step
     yy = yy.astype(int)
 
-    for n in range(0, lenx):
-        indexx = xx[n]
-        indexy = yy[n]
-
-        indexx -= 1  # adjust indices to start at zero, not one like in MATLAB
-        indexy -= 1
-
-        if indexx >= 0 and indexx <= ncellx - 1 and indexy >= 0 and indexy <= ncelly - 1:
-            result[indexx, indexy] = result[indexx, indexy] + 1
+    # Vectorised scatter-add. xx/yy are already rounded ints; subtract 1 for 0-based
+    # indices, mask to the in-bounds cells (same test as the loop), accumulate once.
+    ix = xx - 1
+    iy = yy - 1
+    in_bounds = (ix >= 0) & (ix <= ncellx - 1) & (iy >= 0) & (iy <= ncelly - 1)
+    np.add.at(result, (ix[in_bounds], iy[in_bounds]), 1)
 
     return result, descriptor

--- a/pyhctsa/operations/information.py
+++ b/pyhctsa/operations/information.py
@@ -28,16 +28,15 @@ def _get_corr_fn(y: np.ndarray, min_what: str, extra_param: Union[int, float, No
     else:
         raise ValueError(f"Unknown correlation type specified: {min_what}")
 
-def _first_min_mi_gaussian(y: np.ndarray):
-    """Vectorised path for ``first_min(y, 'mi')`` / ``'mi-gaussian'``.
+def _ami_gaussian_curve(y: np.ndarray):
+    """Gaussian automutual information at every lag 1..n-1 in one O(n log n) pass.
 
-    Evaluates the Gaussian automutual information at every lag in a single
-    O(n log n) pass. Reproduces the windowed Pearson estimate.
+    Reproduces the windowed Pearson estimate (== ``GaussianMI`` on the 1-D delay
+    pair); a degenerate (constant) delay window gives NaN at that lag. Assumes
+    ``n >= 3`` (guarded by ``_self_corr_curve``).
     """
     y = np.asarray(y, dtype=float)
     n = y.size
-    if n < 3:
-        return np.nan
     yc = y - y.mean()                      
     # linear autocorrelation  C[tau] = sum_t yc[t]*yc[t+tau]  via zero-padded FFT
     nfft = 1 << (2 * n - 1).bit_length()
@@ -57,16 +56,58 @@ def _first_min_mi_gaussian(y: np.ndarray):
         r = np.clip(num / np.sqrt(den), -1.0, 1.0)
         auto_corr = -0.5 * np.log(1.0 - r * r)         # AMI(tau), Gaussian estimator
     auto_corr[~(den > 0.0)] = np.nan                   # degenerate window -> NaN
-    # identical first-minimum scan: lags 1..n-1 map to auto_corr[0..n-2]
-    for i in range(1, n):
-        if np.isnan(auto_corr[i - 1]):
-            logger.warning("No minimum in mi: encountered NaN.")
+    return auto_corr
+
+
+
+_VECTORISED_CORR = ('ac', 'mi', 'mi-gaussian')
+
+def _self_corr_curve(y: np.ndarray, what: str):
+    """Full self-correlation curve at lags 1..n-1 for a vectorisable estimator.
+
+    ``'ac'`` -> the FFT autocorrelation, computed once (cf. ``first_crossing``);
+    ``'mi'`` / ``'mi-gaussian'`` -> the Gaussian AMI curve. Returns ``None`` when
+    the series is too short to have an interior extremum (``n < 3``).
+    """
+    y = np.asarray(y, dtype=float)
+    n = y.size
+    if n < 3:
+        return None
+    if what == 'ac':
+        from ..operations.correlation import autocorr
+        c = np.asarray(autocorr(y, [], 'Fourier'), dtype=float).ravel()
+        return c[1:n]                                  # drop lag 0 -> lags 1..n-1
+    return _ami_gaussian_curve(y)                       # 'mi' / 'mi-gaussian'
+
+
+def _first_min_from_curve(c: np.ndarray):
+    """First strict local minimum of a precomputed lag-curve (lags 1..len(c))."""
+    for i in range(1, len(c) + 1):
+        if np.isnan(c[i - 1]):
+            logger.warning("No minimum: encountered NaN.")
             return np.nan
-        if (i == 2) and (auto_corr[1] > auto_corr[0]):
+        if (i == 2) and (c[1] > c[0]):
             return 1
-        elif (i > 2) and auto_corr[i - 3] > auto_corr[i - 2] < auto_corr[i - 1]:
+        elif (i > 2) and c[i - 3] > c[i - 2] < c[i - 1]:
             return i - 1
     return np.nan
+
+
+def _first_max_from_curve(c: np.ndarray):
+    """First strict local maximum of a precomputed lag-curve (lags 1..len(c))."""
+    for i in range(1, len(c) + 1):
+        if np.isnan(c[i - 1]):
+            logger.warning("No maximum: encountered NaN.")
+            return np.nan
+        if (i > 2) and c[i - 3] < c[i - 2] > c[i - 1]:
+            return i - 1
+    return np.nan
+
+
+def _first_min_mi_gaussian(y: np.ndarray):
+    """First minimum of the Gaussian AMI (vectorised); see ``_ami_gaussian_curve``."""
+    c = _self_corr_curve(np.asarray(y), 'mi')
+    return np.nan if c is None else _first_min_from_curve(c)
 
 def first_min(
     y: list,
@@ -108,8 +149,9 @@ def first_min(
     """
     y = np.asarray(y)
     n = len(y)
-    if min_what in ('mi', 'mi-gaussian'):          # vectorised drop-in, identical lag
-        return _first_min_mi_gaussian(y)
+    if min_what in _VECTORISED_CORR:               # vectorised drop-in, identical lag
+        c = _self_corr_curve(y, min_what)
+        return np.nan if c is None else _first_min_from_curve(c)
     corrfn = _get_corr_fn(y, min_what, extra_param)
     
     auto_corr = np.zeros(n - 1)
@@ -166,6 +208,9 @@ def first_max(
     """
     y = np.asarray(y)
     n = len(y)
+    if max_what in _VECTORISED_CORR:               # vectorised drop-in, identical lag
+        c = _self_corr_curve(y, max_what)
+        return np.nan if c is None else _first_max_from_curve(c)
     corrfn = _get_corr_fn(y, max_what, extra_param)
     
     auto_corr = np.zeros(n - 1)

--- a/pyhctsa/operations/information.py
+++ b/pyhctsa/operations/information.py
@@ -28,6 +28,46 @@ def _get_corr_fn(y: np.ndarray, min_what: str, extra_param: Union[int, float, No
     else:
         raise ValueError(f"Unknown correlation type specified: {min_what}")
 
+def _first_min_mi_gaussian(y: np.ndarray):
+    """Vectorised path for ``first_min(y, 'mi')`` / ``'mi-gaussian'``.
+
+    Evaluates the Gaussian automutual information at every lag in a single
+    O(n log n) pass. Reproduces the windowed Pearson estimate.
+    """
+    y = np.asarray(y, dtype=float)
+    n = y.size
+    if n < 3:
+        return np.nan
+    yc = y - y.mean()                      
+    # linear autocorrelation  C[tau] = sum_t yc[t]*yc[t+tau]  via zero-padded FFT
+    nfft = 1 << (2 * n - 1).bit_length()
+    fy = np.fft.rfft(yc, nfft)
+    C_all = np.fft.irfft(fy * np.conj(fy), nfft)[:n]
+    # per-window sums for the two delayed segments y[:-tau] and y[tau:]
+    P = np.concatenate(([0.0], np.cumsum(yc)))         # P[k] = sum_{t<k} yc[t]
+    Q = np.concatenate(([0.0], np.cumsum(yc * yc)))    # Q[k] = sum_{t<k} yc[t]^2
+    taus = np.arange(1, n)
+    m = (n - taus).astype(float)
+    S1 = P[n - taus]; S2 = P[n] - P[taus]
+    Q1 = Q[n - taus]; Q2 = Q[n] - Q[taus]
+    C = C_all[taus]
+    num = m * C - S1 * S2
+    den = (m * Q1 - S1 * S1) * (m * Q2 - S2 * S2)
+    with np.errstate(invalid='ignore', divide='ignore'):
+        r = np.clip(num / np.sqrt(den), -1.0, 1.0)
+        auto_corr = -0.5 * np.log(1.0 - r * r)         # AMI(tau), Gaussian estimator
+    auto_corr[~(den > 0.0)] = np.nan                   # degenerate window -> NaN
+    # identical first-minimum scan: lags 1..n-1 map to auto_corr[0..n-2]
+    for i in range(1, n):
+        if np.isnan(auto_corr[i - 1]):
+            logger.warning("No minimum in mi: encountered NaN.")
+            return np.nan
+        if (i == 2) and (auto_corr[1] > auto_corr[0]):
+            return 1
+        elif (i > 2) and auto_corr[i - 3] > auto_corr[i - 2] < auto_corr[i - 1]:
+            return i - 1
+    return np.nan
+
 def first_min(
     y: list,
     min_what: str = 'mi-gaussian',
@@ -68,6 +108,8 @@ def first_min(
     """
     y = np.asarray(y)
     n = len(y)
+    if min_what in ('mi', 'mi-gaussian'):          # vectorised drop-in, identical lag
+        return _first_min_mi_gaussian(y)
     corrfn = _get_corr_fn(y, min_what, extra_param)
     
     auto_corr = np.zeros(n - 1)

--- a/pyhctsa/operations/medical.py
+++ b/pyhctsa/operations/medical.py
@@ -160,44 +160,14 @@ def hrv_classic(y: ArrayLike) -> dict:
 
     f_bin_size = f[1] - f[0]
 
-    ind_l = []
-    for x in f:
-        if x >= lf_lo and x <= lf_hi:
-            ind_l.append(1)
-        else:
-            ind_l.append(0)
-
-    ind_h = []
-    for x in f:
-        if x >= hf_lo and x <= hf_hi:
-            ind_h.append(1)
-        else:
-            ind_h.append(0)
-
-    ind_v = []
-    for x in f:
-        if x <= lf_lo:
-            ind_v.append(1)
-        else:
-            ind_v.append(0)
-
-    ind_l_pxx = []
-    for i in range(0, len(pxx)):
-        if ind_l[i] == 1:
-            ind_l_pxx.append(pxx[i])
-    lf_p = f_bin_size * np.sum(ind_l_pxx)
-
-    ind_h_pxx = []
-    for i in range(0, len(pxx)):
-        if ind_h[i] == 1:
-            ind_h_pxx.append(pxx[i])
-    hf_p = f_bin_size * np.sum(ind_h_pxx)
-
-    ind_v_pxx = []
-    for i in range(0, len(pxx)):
-        if ind_v[i] == 1:
-            ind_v_pxx.append(pxx[i])
-    vlf_p = f_bin_size * np.sum(ind_v_pxx)
+    # Vectorised band selection. pxx[mask] keeps ascending-index order, so the
+    # masked np.sum matches the original loop's summation order.
+    ind_l = (f >= lf_lo) & (f <= lf_hi)
+    ind_h = (f >= hf_lo) & (f <= hf_hi)
+    ind_v = (f <= lf_lo)
+    lf_p = f_bin_size * np.sum(pxx[ind_l])
+    hf_p = f_bin_size * np.sum(pxx[ind_h])
+    vlf_p = f_bin_size * np.sum(pxx[ind_v])
 
     out['lfhf'] = lf_p / hf_p
     total = f_bin_size * np.sum(pxx)

--- a/pyhctsa/operations/model_fit.py
+++ b/pyhctsa/operations/model_fit.py
@@ -3,6 +3,7 @@ from typing import Union
 import numba
 import numpy as np
 from numpy.typing import ArrayLike
+from numpy.lib.stride_tricks import sliding_window_view
 from hmmlearn.hmm import GaussianHMM
 from scipy.signal import lfilter
 from scipy.stats import ks_1samp, norm, t
@@ -325,11 +326,13 @@ def local_simple(y: ArrayLike, forecast_meth: str = 'mean',
         return np.nan
     res = np.zeros(len(evalr))
     if forecast_meth == 'mean':
-        for i in range(len(evalr)):
-            res[i] = np.mean(y[evalr[i]-lp:evalr[i]]) - y[evalr[i]] # prediction - value
+        # All length-lp windows at once. W.mean(axis=1) reduces the same contiguous
+        # elements in the same order as np.mean(window), so it is bit-identical.
+        W = sliding_window_view(y, lp)[:len(evalr)]
+        res = W.mean(axis=1) - y[evalr]  # prediction - value
     elif forecast_meth == 'median':
-        for i in range(len(evalr)):
-            res[i] = np.median(y[evalr[i]-lp:evalr[i]]) - y[evalr[i]]  # prediction - value
+        W = sliding_window_view(y, lp)[:len(evalr)]
+        res = np.median(W, axis=1) - y[evalr]  # prediction - value
     elif forecast_meth == 'lfit':
         for i in range(len(evalr)):
             # Fit linear

--- a/pyhctsa/operations/spectral.py
+++ b/pyhctsa/operations/spectral.py
@@ -352,13 +352,14 @@ def _findpeaks(s, min_pk_dist=0, sort_str='none'):
     inf_peaks = np.where(np.isinf(s) & (s > 0))[0]
 
     # Find finite peaks by checking if each point is greater than both neighbors
-    finite_peaks = []
-    for i in range(1, len(s) - 1):
-        if not np.isinf(s[i]) and not np.isnan(s[i]):
-            if s[i] > s[i - 1] and s[i] > s[i + 1]:
-                finite_peaks.append(i)
-
-    finite_peaks = np.array(finite_peaks, dtype=int)
+    # Vectorised: a finite interior point strictly greater than both neighbours.
+    # np.isfinite excludes +/-inf and nan, matching `not isinf and not isnan`.
+    if len(s) < 3:
+        finite_peaks = np.array([], dtype=int)
+    else:
+        mid = s[1:-1]
+        cond = np.isfinite(mid) & (mid > s[:-2]) & (mid > s[2:])
+        finite_peaks = (np.flatnonzero(cond) + 1).astype(int)
 
     # Combine finite and infinite peaks
     all_peaks = np.concatenate([finite_peaks, inf_peaks]) if len(inf_peaks) > 0 else finite_peaks
@@ -392,11 +393,9 @@ def _findpeaks(s, min_pk_dist=0, sort_str='none'):
         # keep only non-deleted peaks
         final_peaks = sorted_peaks[~to_delete]
 
-        # convert back to original indices for sorting
-        back_to_original = np.zeros(len(final_peaks), dtype=int)
-        for i, peak in enumerate(final_peaks):
-            back_to_original[i] = np.where(all_peaks == peak)[0][0]
-
+        # convert back to original indices for sorting. all_peaks is sorted-ascending
+        # and unique, so positions come from one searchsorted instead of an O(p^2) scan.
+        back_to_original = np.searchsorted(all_peaks, final_peaks)
         final_peaks = all_peaks[np.sort(back_to_original)]
     else:
         final_peaks = all_peaks

--- a/pyhctsa/operations/stationarity.py
+++ b/pyhctsa/operations/stationarity.py
@@ -145,11 +145,17 @@ def dyn_win(y: ArrayLike, max_num_segments: int = 10) -> dict:
             sampen_out = sample_entropy(y_sub, 2, 0.15)
             qs[j, 4] = sampen_out['quadSampEn1']  # SampEn_1_015
             #qs[j, 5] = sampen_out['quadSampEn2'] # SampEn_2_015
-            qs[j, 6] = autocorr(y_sub, 1, 'Fourier')[0]  # AC1
-            qs[j, 7] = autocorr(y_sub, 2, 'Fourier')[0]  # AC2
+            # One FFT autocorrelation per window instead of four; index the lags.
+            # acf_w[t] is bit-identical to autocorr(y_sub, t, 'Fourier')[0]; the guards
+            # reproduce autocorr's out-of-range -> NaN behaviour exactly.
+            acf_w = autocorr(y_sub, [], 'Fourier')
+            Lw = len(acf_w)
+            _pick = lambda t: acf_w[t] if 0 <= t <= Lw - 1 else np.nan
+            qs[j, 6] = acf_w[1] if Lw > 1 else np.nan  # AC1
+            qs[j, 7] = acf_w[2] if Lw > 2 else np.nan  # AC2
             # (Sometimes tau_g or taul can be longer than ySub; then these will output NaNs:)
-            qs[j, 8] = autocorr(y_sub, tau_g, 'Fourier')[0]  # AC_glob_tau
-            qs[j, 9] = autocorr(y_sub, tau_l, 'Fourier')[0]  # AC_loc_tau
+            qs[j, 8] = _pick(tau_g)  # AC_glob_tau
+            qs[j, 9] = _pick(tau_l)  # AC_loc_tau
             qs[j, 10] = tau_l
 
         fs[i, :num_features] = np.std(qs, ddof=1, axis=0)
@@ -543,10 +549,10 @@ def range_evolve(y: ArrayLike) -> dict:
     y = np.asarray(y)
     N = len(y)
     out = {} # initialise storage
-    cums = np.zeros(N)
-    for i in range(N):
-        cums[i] = np.ptp(y[:i+1])  # np.ptp calculates the range (peak to peak)
-    
+    # Running peak-to-peak == cumulative max minus cumulative min: O(N) one pass
+    # instead of O(N^2) np.ptp over growing prefixes. Picks the same values.
+    cums = (np.maximum.accumulate(y) - np.minimum.accumulate(y)).astype(float)
+
     fullr = np.ptp(y)
 
     # return number of unique entries in a vector, x

--- a/pyhctsa/operations/wavelet.py
+++ b/pyhctsa/operations/wavelet.py
@@ -474,10 +474,12 @@ def detail_coeffs(y: ArrayLike, w_name: str = 'db3', max_level: Union[int, str] 
     medians = np.zeros(max_level) # median detail coefficient magnitude at each level
     maxs = np.zeros(max_level) # max detail coefficient magnitude at each level
     
+    # Decompose once at the maximum level; wavedec is prefix-stable, so the level-k
+    # detail branch is identical whether decomposed to level k or to max_level. Reusing
+    # one (c, l) is bit-identical to re-running wavedec at each level.
+    c, l = wavedec(data=y, wavelet=w_name, level=max_level)
     for k in range(1, max_level+1):
-        level = k
-        c, l = wavedec(data=y, wavelet=w_name, level=level)
-        det = wrcoef(coefs=c, lengths=l, wavelet=w_name, level=level)
+        det = wrcoef(coefs=c, lengths=l, wavelet=w_name, level=k)
         absdet = np.abs(det)
         means[k-1] = np.mean(absdet)
         medians[k-1] = np.median(absdet)

--- a/pyhctsa/utils.py
+++ b/pyhctsa/utils.py
@@ -274,9 +274,11 @@ def histc(x: ArrayLike, bins: ArrayLike) -> int:
     """Counts the number of values in x that are within each specified bin."""
     # Get indices of the bins to which each value in input array belongs.
     map_to_bins = np.digitize(x, bins)
-    res = np.zeros(bins.shape)
-    for el in map_to_bins:
-        res[el-1] += 1 # Increment appropriate bin.
+    # Vectorised count. (idx - 1) % nbins reproduces the original loop's res[el-1]
+    # wrap-around exactly: below-range (el==0) -> -1 -> last bin; above-range
+    # (el==nbins) -> nbins-1 -> last bin.
+    nbins = bins.shape[0]
+    res = np.bincount((map_to_bins - 1) % nbins, minlength=nbins).astype(float)
     return res
 
 def bin_picker(x_min: float, x_max: float, n_bins: Union[None, int],
@@ -400,15 +402,12 @@ def simple_binner(x_data: ArrayLike, num_bins: int) -> tuple:
     
     # Linearly spaced bins:
     bin_edges = np.linspace(min_x, max_x, num_bins + 1)
-    N = np.zeros(num_bins, dtype=int)
-    
-    for i in range(num_bins):
-        if i < num_bins - 1:
-            N[i] = np.sum((x_data >= bin_edges[i]) & (x_data < bin_edges[i+1]))
-        else:
-            # the final bin
-            N[i] = np.sum((x_data >= bin_edges[i]) & (x_data <= bin_edges[i+1]))
-    
+    # Vectorised: searchsorted against the interior edges gives each point's bin in
+    # one pass (half-open interior bins; the max value equals the last edge so it
+    # lands in the final inclusive bin, matching the loop).
+    idx = np.searchsorted(bin_edges[1:-1], x_data, side='right')
+    N = np.bincount(idx, minlength=num_bins).astype(int)
+
     return N, bin_edges
 
 def point_of_crossing(x: ArrayLike, threshold: float) -> tuple:


### PR DESCRIPTION
This PR started by swapping the lag-by-lag computation of the 'Gaussian AMI' (reducible to the Pearson correlation) to a vectorized fft. This saves ~200x computation on slow-timescale series of length N = 10000 (commit 7547244)

It seems like a similar swap can be made for many other features which rely on the autocorrelation function, so subsequent commits swap out the AC method in other features

The final commit also improves performance for other features such as wavelets and histc; all new code produces identical feature values

This makes a sizable difference at larger N; 
N = 5000 -> saves 1s/30s
N = 10000 -> saves 8s / 60s
N = 50000 -> saves 40s/200s

Features updated:

noisy_sine/correlation.autocorr_shape
noisy_sine/correlation.embed2_shapes
noisy_sine/entropy.permutation_entropy
noisy_sine/information.automutual_info
noisy_sine/information.first_min
noisy_sine/medical.hrv_classic
noisy_sine/model_fit.local_simple
noisy_sine/stationarity.dyn_win
noisy_sine/stationarity.range_evolve
noisy_sine/utils.histc
noisy_sine/utils.simple_binner
noisy_sine/wavelet.detail_coeffs
walk/correlation.autocorr_shape
walk/correlation.embed2_shapes
walk/entropy.permutation_entropy
walk/information.automutual_info
walk/information.first_min
walk/medical.hrv_classic
walk/model_fit.local_simple
walk/stationarity.dyn_win
walk/stationarity.range_evolve
walk/utils.histc
walk/utils.simple_binner
walk/wavelet.detail_coeffs
white/correlation.autocorr_shape
white/correlation.embed2_shapes
white/entropy.permutation_entropy
white/information.automutual_info
white/information.first_min
white/medical.hrv_classic
white/model_fit.local_simple
white/stationarity.dyn_win
white/stationarity.range_evolve
white/utils.histc
white/utils.simple_binner
white/wavelet.detail_coeffs