### PR TITLE
Fix stationarity.py for short window lengths

### DIFF
--- a/pyhctsa/operations/stationarity.py
+++ b/pyhctsa/operations/stationarity.py
@@ -408,7 +408,7 @@ def local_extrema(y: ArrayLike, how_to_window: str = 'l', n: Union[int, None] = 
     
     if (window_length > N) or (window_length <= 1):
         # This feature is unsuitable if the window length exceeds ts
-        out = np.nan
+        return np.nan
     
     # Buffer the time series
     y_buff = make_mat_buffer(y, window_length) # no overlap


### PR DESCRIPTION
Previously, when window_length > N, the function would continue and try to buffer the short time series, leading to a hang. Now we add 'return np.nan' to exit early