### PR TITLE
Add iteration count to hmm feature output

### DIFF
--- a/pyhctsa/operations/model_fit.py
+++ b/pyhctsa/operations/model_fit.py
@@ -86,6 +86,7 @@ def hmm_fit(y: ArrayLike, train_p: float = 0.8, num_states: int = 3, random_seed
     #% Within-sample log-likelihood
     train_ll = model.score(y_train_reshaped)
     out['LLtrainpersample'] = train_ll / n_train
+    out['nit'] = model.monitor_.iter
 
     #Calculate log likelihood for the test data
     out['LLtestpersample'] = model.score(y_test_reshaped)/n_test


### PR DESCRIPTION
Just flagging this for discussion: MF_hmm_fit in hctsa also emits the number of iterations taken to converge. Very cheap to report but no strong reason to include it except completeness

See https://github.com/benfulcher/hctsa/blob/bae5c5e8347e45c2731c271b60334fd73d562b81/Operations/MF_hmm_fit.m#L123