### PR TITLE
Speed up hypothesis_test

### DIFF
--- a/pyhctsa/operations/hypothesis_tests.py
+++ b/pyhctsa/operations/hypothesis_tests.py
@@ -3,10 +3,9 @@ from typing import Union
 import numpy as np
 from numpy.typing import ArrayLike
 from arch.unitroot import VarianceRatio
-from scipy.stats import jarque_bera, norm, wilcoxon
+from scipy.stats import jarque_bera, norm, wilcoxon, chi2
 from statsmodels.sandbox.stats.runs import runstest_1samp
 from statsmodels.stats.descriptivestats import sign_test
-from statsmodels.stats.diagnostic import acorr_ljungbox
 
 def variance_ratio_test(y: ArrayLike, periods: Union[int, list[int], float] = 2,
                         iids: Union[int, list[int]] = 0) -> dict:
@@ -134,10 +133,19 @@ def hypothesis_test(x: ArrayLike, the_test: str = 'signtest') -> float:
     elif the_test == 'signrank':
         _, p = wilcoxon(x)
     elif the_test == 'lbq':
-        # Ljung-Box Q-test for residual autocorrelation
+        # Ljung-Box Q-test for residual autocorrelation. Matches
+        # acorr_ljungbox(x, lags=[n_lags]) to ~1e-15 but is O(N*n_lags) not
+        # O(N^2): forms only the needed autocovariances instead of statsmodels'
+        # full acf(fft=False).
         t = np.sum(~np.isnan(x)) # get the effective sample size
         n_lags = min(20, t-1)
-        p = acorr_ljungbox(x, lags=[n_lags])['lb_pvalue'].to_numpy()[0]
+        nobs = x.shape[0]
+        xo = x - x.mean()
+        acov = np.array([np.dot(xo[:nobs-k], xo[k:]) for k in range(n_lags+1)]) / nobs
+        sacf = acov / acov[0]
+        sacf2 = sacf[1:n_lags+1]**2 / (nobs - np.arange(1, n_lags+1))
+        q = nobs * (nobs+2) * np.cumsum(sacf2)[n_lags-1]
+        p = chi2.sf(q, n_lags)
     else:
         raise ValueError(f"Unknown test: {the_test}.")
     return p


### PR DESCRIPTION
Flagging this also; `acorr_ljungbox(x, lags=[n_lags])` computes the acf at ALL lags before trimming to n_lags. Since we only need 20 lags, it might make more sense to manually compute the Ljung-Box Q-test

Since the acf is quite cheap, this only makes a difference for quite long time series (N = 20000), but at this length it turns an O(n^2) into O(20*N).